### PR TITLE
Add autorepeat_rate parameter to teleop launch

### DIFF
--- a/fetch_bringup/launch/include/teleop.launch.xml
+++ b/fetch_bringup/launch/include/teleop.launch.xml
@@ -1,6 +1,8 @@
 <launch>
 
-  <node name="joy" pkg="joy" type="joy_node"/>
+  <node name="joy" pkg="joy" type="joy_node">
+  	<param name="autorepeat_rate" value="1"/>
+  </node>
 
   <node name="teleop" pkg="fetch_teleop" type="joystick_teleop" />
 

--- a/freight_bringup/launch/include/teleop.launch.xml
+++ b/freight_bringup/launch/include/teleop.launch.xml
@@ -1,6 +1,8 @@
 <launch>
 
-  <node name="joy" pkg="joy" type="joy_node"/>
+  <node name="joy" pkg="joy" type="joy_node">
+  	<param name="autorepeat_rate" value="1"/>
+  </node>
 
   <node name="teleop" pkg="fetch_teleop" type="joystick_teleop" output="screen">
     <param name="is_fetch" value="false"/>


### PR DESCRIPTION
This adds the autorepeat_rate parameter to the teleop launch. It requires Mike Purvis's new sixad drivers as mentioned in https://github.com/fetchrobotics/engineering/issues/353.
