### PR TITLE
PMD/pico_flexx_driver no longer part of robot service

### DIFF
--- a/freight_bringup/launch/freight.launch
+++ b/freight_bringup/launch/freight.launch
@@ -28,9 +28,6 @@
   <!-- Laser -->
   <include file="$(find freight_bringup)/launch/include/laser.launch.xml" />
 
-  <!-- PMD -->
-  <include file="$(find freight_bringup)/launch/include/base_camera_pmd.launch.xml" />
-
   <!-- Teleop -->
   <include file="$(find freight_bringup)/launch/include/teleop.launch.xml" />
 

--- a/freight_bringup/launch/include/base_camera_pmd.launch
+++ b/freight_bringup/launch/include/base_camera_pmd.launch
@@ -35,7 +35,7 @@
   <group ns="base_camera">
     <!-- Nodelet manager. -->
     <node pkg="nodelet" type="nodelet" name="$(arg nodelet_manager)" args="manager"
-          if="$(arg start_manager)" machine="$(arg machine)" output="screen"/>
+          if="$(arg start_manager)" machine="$(arg machine)" respawn="true" output="screen"/>
 
     <!-- pico_flexx_driver nodelet. -->
     <node pkg="nodelet" type="nodelet" name="$(arg base_name)_driver" machine="$(arg machine)"

--- a/freight_bringup/package.xml
+++ b/freight_bringup/package.xml
@@ -13,7 +13,6 @@
   <run_depend>fetch_teleop</run_depend>
   <run_depend>graft</run_depend>
   <run_depend>joy</run_depend>
-  <run_depend>pico_flexx_driver</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend version_gte="0.0.4">sick_tim</run_depend>
   <run_depend version_gt="1.6.0">sixad</run_depend>


### PR DESCRIPTION
Assuming we want to go ahead with making the base_camera a separate upstart process, so moving the driver launch to an upstart job in freight-system-config
