### PR TITLE
Add install rule for software runstop

### DIFF
--- a/fetch_bringup/CMakeLists.txt
+++ b/fetch_bringup/CMakeLists.txt
@@ -18,3 +18,8 @@ install(
   PROGRAMS scripts/controller_reset.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
+
+install(
+  PROGRAMS scripts/software_runstop.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)


### PR DESCRIPTION
Haven't actually tested this since I don't know packages, but found it was probably something missing during a manual install of the software runstop.
