### PR TITLE
SLAMN-599 : Modifies default controller selection for freight bringup

### DIFF
--- a/freight_bringup/config/default_controllers.yaml
+++ b/freight_bringup/config/default_controllers.yaml
@@ -1,5 +1,5 @@
 base_controller:
-  type: "robot_controllers/DiffDriveBaseController"
+  type: "freight_base_controller/DiffDriveBaseController"
   max_velocity_x: 1.5
   max_acceleration_x: 2.0
   # hold position


### PR DESCRIPTION
JIRA Ticket: https://fetchrobotics.atlassian.net/browse/SLAMN-599

## Description
- Swaps in `robot_private` version of base controller in freight bring-up
- Associated with https://github.com/fetchrobotics/robot_private/pull/12 and https://github.com/fetchrobotics/navigation/pull/544

## Tests
- 

## Open questions for reviewers
- 

## How to revert
- ` type: "robot_controllers/DiffDriveBaseController"`
