### PR TITLE
Update maintaner; rm sixad dep

### DIFF
--- a/fetch_bringup/package.xml
+++ b/fetch_bringup/package.xml
@@ -5,7 +5,7 @@
     Bringup for fetch
   </description>
   <author>Michael Ferguson</author>
-  <maintainer email="mferguson@fetchrobotics.com">Michael Ferguson</maintainer>
+  <maintainer email="erelson@fetchrobotics.com">Eric Relson</maintainer>
   <license>Proprietary</license>
   <buildtool_depend>catkin</buildtool_depend>
   <run_depend>depth_image_proc</run_depend>
@@ -21,5 +21,4 @@
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend version_gte="0.0.4">sick_tim</run_depend>
-  <run_depend version_gt="1.6.0">sixad</run_depend>
 </package>

--- a/freight_bringup/package.xml
+++ b/freight_bringup/package.xml
@@ -5,7 +5,7 @@
     Bringup for freight
   </description>
   <author>Michael Ferguson</author>
-  <maintainer email="mferguson@fetchrobotics.com">Michael Ferguson</maintainer>
+  <maintainer email="erelson@fetchrobotics.com">Eric Relson</maintainer>
   <license>Proprietary</license>
   <buildtool_depend>catkin</buildtool_depend>
   <run_depend>diagnostic_aggregator</run_depend>
@@ -16,5 +16,4 @@
   <run_depend>joy</run_depend>
   <run_depend>robot_state_publisher</run_depend>
   <run_depend>sick_tim</run_depend>
-  <run_depend>sixad</run_depend>
 </package>


### PR DESCRIPTION
My understanding is that sixad is in the kernel, so the debian is no longer available.  As well, presently in testing we use ps3joy for PS3 controllers.