### PR TITLE
Add depend urdfdom, and switch to <depend>

### DIFF
--- a/fetch_binary_drivers/package.xml
+++ b/fetch_binary_drivers/package.xml
@@ -35,30 +35,31 @@
   <build_depend>rospack</build_depend>
 
   <!-- system dependencies which the drivers dyanmically link against -->
-  <build_depend>boost</build_depend>
-  <build_depend>curl</build_depend>
-  <build_depend>python</build_depend>
-  <build_depend>yaml-cpp</build_depend>
+  <depend>boost</depend>
+  <depend>curl</depend>
+  <depend>python</depend>
+  <depend>yaml-cpp</depend>
 
   <!-- ros msgs which the drivers depend on -->
-  <exec_depend>actionlib_msgs</exec_depend>
-  <exec_depend>diagnostic_msgs</exec_depend>
-  <exec_depend>fetch_driver_msgs</exec_depend>
-  <exec_depend>fetch_auto_dock_msgs</exec_depend>
-  <exec_depend>nav_msgs</exec_depend>
-  <exec_depend>power_msgs</exec_depend>
-  <exec_depend>robot_calibration_msgs</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
+  <depend>actionlib_msgs</depend>
+  <depend>diagnostic_msgs</depend>
+  <depend>fetch_driver_msgs</depend>
+  <depend>fetch_auto_dock_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>power_msgs</depend>
+  <depend>robot_calibration_msgs</depend>
+  <depend>sensor_msgs</depend>
 
   <!-- ros dependencies which the drivers dynamically link against -->
-  <exec_depend>actionlib</exec_depend>
-  <exec_depend>robot_controllers</exec_depend>
-  <exec_depend>robot_controllers_interface</exec_depend>
-  <exec_depend>rosconsole</exec_depend>
-  <exec_depend>roscpp_serialization</exec_depend>
-  <exec_depend>roscpp</exec_depend>
-  <exec_depend>rostime</exec_depend>
-  <exec_depend>urdf</exec_depend>
+  <depend>actionlib</depend>
+  <depend>robot_controllers</depend>
+  <depend>robot_controllers_interface</depend>
+  <depend>rosconsole</depend>
+  <depend>roscpp_serialization</depend>
+  <depend>roscpp</depend>
+  <depend>rostime</depend>
+  <depend>urdf</depend>
+  <depend>urdfdom</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/fetch_binary_drivers/package.xml
+++ b/fetch_binary_drivers/package.xml
@@ -59,7 +59,7 @@
   <depend>roscpp</depend>
   <depend>rostime</depend>
   <depend>urdf</depend>
-  <depend>urdfdom</depend>
+  <depend>liburdfdom-dev</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
These were <exec_depend> because this doesn't compile the drivers.
But we will use <depend> and clean things up later.

But the jenkins job failed after:
https://github.com/ros/rosdistro/pull/20327
Fix #31 (or work around it until the next issue)