### PR TITLE
Add argument to select launching teleop

### DIFF
--- a/fetch_bringup/launch/fetch.launch
+++ b/fetch_bringup/launch/fetch.launch
@@ -2,6 +2,7 @@
   <!-- robot specific information on parameters https://github.com/ros-infrastructure/rep/pull/104 -->
   <param name="robot/type" value="fetch" />
   <param name="robot/name" textfile="/etc/hostname" />
+  <arg name="launch_teleop" default="true" />
 
   <!-- GDB Debug Option -->
   <arg name="debug" default="false" />
@@ -54,7 +55,7 @@
   <include file="$(find fetch_bringup)/launch/include/laser.launch.xml" />
 
   <!-- Teleop -->
-  <include file="$(find fetch_bringup)/launch/include/teleop.launch.xml" />
+  <include if="$(arg launch_teleop)" file="$(find fetch_bringup)/launch/include/teleop.launch.xml" />
 
   <!-- Software Runstop -->
   <include file="$(find fetch_bringup)/launch/include/runstop.launch.xml">

--- a/freight_bringup/launch/freight.launch
+++ b/freight_bringup/launch/freight.launch
@@ -2,6 +2,7 @@
   <!-- robot specific information on parameters https://github.com/ros-infrastructure/rep/pull/104 -->
   <param name="robot/type" value="freight" />
   <param name="robot/name" textfile="/etc/hostname" />
+  <arg name="launch_teleop" default="true" />
 
   <!-- Calibration -->
   <param name="calibration_date" value="uncalibrated"/>
@@ -33,7 +34,7 @@
   <include file="$(find freight_bringup)/launch/include/laser.launch.xml" />
 
   <!-- Teleop -->
-  <include file="$(find freight_bringup)/launch/include/teleop.launch.xml" />
+  <include if="$(arg launch_teleop)" file="$(find freight_bringup)/launch/include/teleop.launch.xml" />
 
   <!-- Diagnostics Aggregator -->
   <include file="$(find freight_bringup)/launch/include/aggregator.launch.xml" />


### PR DESCRIPTION
In this PR, I add argument to select launching teleop in `fetch.launch`.

I need this argument because I want to launch our original teleop program in other launch file.

Cc @knorth55