### PR TITLE
OPEN-17: PS4 controller support

### DIFF
--- a/fetch_bringup/launch/fetch.launch
+++ b/fetch_bringup/launch/fetch.launch
@@ -55,7 +55,9 @@
   <include file="$(find fetch_bringup)/launch/include/laser.launch.xml" />
 
   <!-- Teleop -->
-  <include if="$(arg launch_teleop)" file="$(find fetch_bringup)/launch/include/teleop.launch.xml" />
+  <include if="$(arg launch_teleop)" file="$(find fetch_bringup)/launch/include/teleop.launch.xml">
+    <arg name="ps4" value="true" />
+  </include>
   <param name="joy/deadzone" value="0.05"/>
 
   <!-- Autodocking -->

--- a/fetch_bringup/launch/include/teleop.launch.xml
+++ b/fetch_bringup/launch/include/teleop.launch.xml
@@ -1,10 +1,19 @@
 <launch>
 
-  <arg name="joy_device" default="/dev/ps3joy"/>
+  <arg name="joy_device" default="/dev/fetch_joy"/>
+  <arg name="ps4" default="false"/>
 
-  <node name="joy" pkg="joy" type="joy_node">
+  <node name="joy_node" pkg="joy" type="joy_node">
     <param name="autorepeat_rate" value="1"/>
     <param name="dev" value="$(arg joy_device)"/>
+    <remap from="joy" to="joy_orig" if="$(arg ps4)"/>
+  </node>
+
+  <!-- remap joy to emulate ps3joy mappings -->
+  <node name="joy_remap" pkg="joy" type="joy_remap.py" if="$(arg ps4)">
+    <remap from="joy_in" to="joy_orig"/>
+    <remap from="joy_out" to="joy"/>
+    <rosparam command="load" file="$(find joy)/config/ps4joy.yaml"/>
   </node>
 
   <node name="teleop" pkg="fetch_teleop" type="joystick_teleop">

--- a/fetch_bringup/package.xml
+++ b/fetch_bringup/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <exec_depend>depth_image_proc</exec_depend>
   <exec_depend>diagnostic_aggregator</exec_depend>
+  <exec_depend>ds4drv-pip</exec_depend>
   <exec_depend>fetch_description</exec_depend>
   <exec_depend>fetch_drivers</exec_depend>
   <exec_depend>fetch_moveit_config</exec_depend>

--- a/fetch_system_config/README.md
+++ b/fetch_system_config/README.md
@@ -7,8 +7,10 @@ of this package, are on the 'master' branch.
 # How to Manually Build
 
 ```bash
-git clone git@github.com:fetchrobotics/fetch_ros.git # -b melodic-devel
-cd fetch_ros/fetch_system_config
+git clone git@github.com:fetchrobotics/fetch_robots.git # -b melodic-devel
+cd fetch_robots/fetch_system_config
+# Optionally auto-update changelog via git commits
+gbp dch --release
 dpkg-buildpackage -us -uc
 # Debians are placed in the parent directory
 cd ..

--- a/fetch_system_config/debian/fetch-melodic-config.ps3joy.service
+++ b/fetch_system_config/debian/fetch-melodic-config.ps3joy.service
@@ -9,8 +9,6 @@ WantedBy=roscore.service
 [Service]
 Environment="ROS_LOG_DIR=/var/log/ros"
 Restart=on-failure
-StandardOutput=file:/var/log/ros/ps3joy.log
-StandardError=file:/var/log/ros/ps3joy.log
 
 ExecStart=/bin/bash -c ". /opt/ros/melodic/setup.bash && rosrun ps3joy ps3joy.py --inactivity-timeout=3600"
 

--- a/fetch_system_config/debian/fetch-melodic-config.ps4joy.service
+++ b/fetch_system_config/debian/fetch-melodic-config.ps4joy.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Job that launches the ds4drv PS4 driver
+Requires=bluetooth.service
+After=bluetooth.service
+
+[Install]
+WantedBy=bluetooth.target
+
+[Service]
+Restart=on-abort
+ExecStart=/bin/bash -c "ds4drv --hidraw"
+

--- a/fetch_system_config/debian/fetch-melodic-config.robot.service
+++ b/fetch_system_config/debian/fetch-melodic-config.robot.service
@@ -9,8 +9,9 @@ WantedBy=roscore.service
 [Service]
 Environment="ROS_LOG_DIR=/var/log/ros"
 Restart=on-failure
-StandardOutput=file:/var/log/ros/robot.log
-StandardError=file:/var/log/ros/robot.log
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifer=robot
 
 User=ros
 ExecStart=/bin/bash -c ". /opt/ros/melodic/setup.bash && roslaunch /etc/ros/melodic/robot.launch --wait"

--- a/fetch_system_config/debian/fetch-melodic-config.ros.logrotate
+++ b/fetch_system_config/debian/fetch-melodic-config.ros.logrotate
@@ -41,25 +41,9 @@ compress
     delaycompress
 }
 
-/var/log/ros/roscore.log {
-    maxsize=50M
-    rotate 3
-    missingok
-    delaycompress
-    # 01 Jan 2013 - BUG: Sending SIGHUP to the ROS does not cause it to write to a new log.
-    copytruncate
-}
-
-/var/log/ros/robot.log {
+/var/log/robot.log {
     maxsize=50M
     rotate 7
-    missingok
-    delaycompress
-}
-
-/var/log/ros/sixad.log {
-    maxsize=50M
-    rotate 3
     missingok
     delaycompress
 }

--- a/fetch_system_config/debian/fetch-melodic-config.roscore.service
+++ b/fetch_system_config/debian/fetch-melodic-config.roscore.service
@@ -8,8 +8,6 @@ WantedBy=multi-user.target
 [Service]
 Environment="ROS_LOG_DIR=/var/log/ros"
 Restart=on-failure
-StandardOutput=file:/var/log/ros/roscore.log
-StandardError=file:/var/log/ros/roscore.log
 
 ExecStartPre=/bin/bash /opt/ros/roscore_prestart.bash
 ExecStartPost=/bin/bash /opt/ros/roscore_poststart.bash

--- a/fetch_system_config/debian/freight-melodic-config.ps4joy.service
+++ b/fetch_system_config/debian/freight-melodic-config.ps4joy.service
@@ -1,0 +1,1 @@
+fetch-melodic-config.ps4joy.service

--- a/fetch_system_config/debian/rules
+++ b/fetch_system_config/debian/rules
@@ -5,8 +5,8 @@
 override_dh_systemd_enable:
 	dh_systemd_enable --name=roscore
 	dh_systemd_enable --name=robot
-	dh_systemd_enable --name=ps3joy
-	#dh_systemd_enable --name=soundplay # TBD
+	dh_systemd_enable --name=ps4joy --no-enable
+	dh_systemd_enable --name=ps3joy --no-enable
 
 override_dh_installlogrotate:
 	dh_installlogrotate --name=ros

--- a/fetch_system_config/root/etc/rsyslog.d/robot.conf
+++ b/fetch_system_config/root/etc/rsyslog.d/robot.conf
@@ -1,0 +1,5 @@
+# Grab the syslog output from 'robot', our systemd launch script's name
+$template cleanFormat, "%msg%\n"
+# And put it in /var/log/robot.log
+if $programname == 'robot.sh' then /var/log/robot.log; cleanFormat
+& stop

--- a/fetch_system_config/root/lib/udev/rules.d/99-ds4drv.rules
+++ b/fetch_system_config/root/lib/udev/rules.d/99-ds4drv.rules
@@ -1,0 +1,7 @@
+KERNEL=="uinput", MODE="0666"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="05c4", MODE="0666"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", KERNELS=="0005:054C:05C4.*", MODE="0666"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="09cc", MODE="0666"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", KERNELS=="0005:054C:09CC.*", MODE="0666"
+KERNEL=="js?", SUBSYSTEM=="input", ATTRS{name}=="Sony Computer Entertainment Wireless Controller", SYMLINK+="ps4joy"
+KERNEL=="js?", SUBSYSTEM=="input", ATTRS{name}=="Sony Computer Entertainment Wireless Controller", SYMLINK+="fetch_joy"

--- a/fetch_system_config/root/lib/udev/rules.d/99-logitechF710.rules
+++ b/fetch_system_config/root/lib/udev/rules.d/99-logitechF710.rules
@@ -1,2 +1,4 @@
 KERNEL=="js?", SUBSYSTEM=="input", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c219", SYMLINK+="logitechF710"
 KERNEL=="js?", SUBSYSTEM=="input", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c21f", SYMLINK+="logitechF710"
+KERNEL=="js?", SUBSYSTEM=="input", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c219", SYMLINK+="fetch_joy"
+KERNEL=="js?", SUBSYSTEM=="input", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c21f", SYMLINK+="fetch_joy"

--- a/fetch_system_config/root/lib/udev/rules.d/99-ps3joy.rules
+++ b/fetch_system_config/root/lib/udev/rules.d/99-ps3joy.rules
@@ -1,1 +1,2 @@
-KERNEL=="js?", SUBSYSTEM=="input", ATTRS{name}=="PLAYSTATION(R)3 Controller *", SYMLINK+="ps3joy"
+KERNEL=="js?", SUBSYSTEM=="input", ATTRS{name}=="Sony Playstation SixAxis/DS3", SYMLINK+="ps3joy"
+KERNEL=="js?", SUBSYSTEM=="input", ATTRS{name}=="Sony Playstation SixAxis/DS3", SYMLINK+="fetch_joy"

--- a/freight_bringup/launch/freight.launch
+++ b/freight_bringup/launch/freight.launch
@@ -34,7 +34,9 @@
   <include file="$(find freight_bringup)/launch/include/laser.launch.xml" />
 
   <!-- Teleop -->
-  <include if="$(arg launch_teleop)" file="$(find freight_bringup)/launch/include/teleop.launch.xml" />
+  <include if="$(arg launch_teleop)" file="$(find freight_bringup)/launch/include/teleop.launch.xml">
+    <arg name="ps4" value="true" />
+  </include>
   <param name="joy/deadzone" value="0.05"/>
 
   <!-- Autodocking -->

--- a/freight_bringup/launch/include/teleop.launch.xml
+++ b/freight_bringup/launch/include/teleop.launch.xml
@@ -1,10 +1,19 @@
 <launch>
 
-  <arg name="joy_device" default="/dev/ps3joy"/>
+  <arg name="joy_device" default="/dev/fetch_joy"/>
+  <arg name="ps4" default="false"/>
 
-  <node name="joy" pkg="joy" type="joy_node">
+  <node name="joy_node" pkg="joy" type="joy_node">
     <param name="autorepeat_rate" value="1"/>
     <param name="dev" value="$(arg joy_device)"/>
+    <remap from="joy" to="joy_orig" if="$(arg ps4)"/>
+  </node>
+
+  <!-- remap joy to emulate ps3joy mappings -->
+  <node name="joy_remap" pkg="joy" type="joy_remap.py" if="$(arg ps4)">
+    <remap from="joy_in" to="joy_orig"/>
+    <remap from="joy_out" to="joy"/>
+    <rosparam command="load" file="$(find joy)/config/ps4joy.yaml"/>
   </node>
 
   <node name="teleop" pkg="fetch_teleop" type="joystick_teleop" output="screen">

--- a/freight_bringup/package.xml
+++ b/freight_bringup/package.xml
@@ -14,6 +14,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <exec_depend>diagnostic_aggregator</exec_depend>
+  <exec_depend>ds4drv-pip</exec_depend>
   <exec_depend>fetch_description</exec_depend>
   <exec_depend>fetch_drivers</exec_depend>
   <exec_depend>fetch_navigation</exec_depend>


### PR DESCRIPTION
We want to move from PS3 controllers to PS4 controllers.  This is a solution to (1) PS3 controllers are very EOL; (2) the unsolved issues with PS3 controllers in 18.04.  This PR takes advantage of (1) the [ds4drv driver](https://github.com/chrippa/ds4drv) for the PS4 controllers, and a [joystick mapping](https://github.com/ros-drivers/joystick_drivers/commit/e6508a15287f1358a67e982adc48844b74b4cdbb) (plus remapping script) that works out of the box, added last year to ros-drivers/joystick_drivers.

While this works, it's still a bit of a hack at present, and needs the (unreleased) files from joystick_drivers.  TODOs I'd like to (attempt to) address before merging:
- [x] bug: it seems that remapping only works if the joy node is not named "joy" as we have historically named it... We're taking the easy route here and renaming the node from joy to joy_node.
- [x] find out if anyone cares whether we call the service ps4joy or ds4drv...
- [x] update udev rules to give us a more predictable device path/name; success: both services now create /dev/ps3joy which is a symlink to /dev/input/js#
- [x] joystick_drivers has been released: https://github.com/ros-drivers/joystick_drivers
- [x] test if systemd jobs for ps3joy/ps4joy are not enabled after installed (as desired)
- [x] determine if ps3joy and ds4drv conflict if run simultaneously
- [x] tweak my open PR in fetch_tools for the changes to files being logged
- [x] documentation updates

Additionally, I've modified how we log services.  Previously I wanted to take the logs that go to journalctl and (also) put them in actual log files (ease of support/troubleshooting).  However, systemd version 237 which ships with Ubuntu 18.04 does not support appending to files, so restarting a service would cause the log file to start being overwritten from the beginning.  So, instead, I'm redirecting output to syslog, and having rsyslog pull relevant portions into a log file.  [Guide for this](https://stackoverflow.com/a/43830129).  So that rsyslog can access the robot.log (via the `adm` group), I moved robot.log from /var/log/ros/robot.log to /var/log/robot.log.

Additionally, because we never end up using the roscore or ps3joy logs when troubleshooting, I moved those back to being handled with journalctl, as is the default for systemd services.