### PR TITLE
Remove unnecessary ethernet gateway specification

### DIFF
--- a/fetch_system_config/root/etc/netplan/99-fetch-ethernet.yaml.default
+++ b/fetch_system_config/root/etc/netplan/99-fetch-ethernet.yaml.default
@@ -6,7 +6,5 @@ network:
   ethernets:
     #eth0:
     #  addresses: [172.42.42.1/24]
-    #  gateway4: 172.42.42.1
     eth1:
       addresses: [10.42.42.1/24]
-      gateway4: 10.42.42.1


### PR DESCRIPTION
This intermittently would cause issues.  There should only be one default route (i.e. in the output of the command `route`) and this extra gateway specification was resulting in a second one where the robot attempted to send outbound traffic to itself. D'oh.