### PR TITLE
Move ds4drv dep from package.xml to sys-config deb

### DIFF
--- a/fetch_bringup/package.xml
+++ b/fetch_bringup/package.xml
@@ -15,7 +15,6 @@
   <buildtool_depend>catkin</buildtool_depend>
   <exec_depend>depth_image_proc</exec_depend>
   <exec_depend>diagnostic_aggregator</exec_depend>
-  <exec_depend>ds4drv-pip</exec_depend>
   <exec_depend>fetch_description</exec_depend>
   <exec_depend>fetch_drivers</exec_depend>
   <exec_depend>fetch_moveit_config</exec_depend>

--- a/fetch_system_config/debian/fetch-melodic-config.postinst
+++ b/fetch_system_config/debian/fetch-melodic-config.postinst
@@ -58,8 +58,8 @@ case "$1" in
             cp /etc/cron.daily/logrotate /etc/cron.hourly/logrotate
         fi
 
-        # Probalby null-op; We replace the update-rc.d with upstart job so that sixad starts properly
-        update-rc.d -f sixad remove
+        # For PS4 controller support, install ds4drv with pip, presuming that pip is installed already
+        pip install ds4drv
 
         ### Set up ethernet to ensure static network for internal robot communications.
         # Reboot required for changes to take effect.

--- a/fetch_system_config/debian/freight-melodic-config.postinst
+++ b/fetch_system_config/debian/freight-melodic-config.postinst
@@ -58,8 +58,8 @@ case "$1" in
             cp /etc/cron.daily/logrotate /etc/cron.hourly/logrotate
         fi
 
-        # Probalby null-op; We replace the update-rc.d with upstart job so that sixad starts properly
-        update-rc.d -f sixad remove
+        # For PS4 controller support, install ds4drv with pip, presuming that pip is installed already
+        pip install ds4drv
 
         ### Set up ethernet to ensure static network for internal robot communications.
         # Reboot required for changes to take effect.

--- a/freight_bringup/package.xml
+++ b/freight_bringup/package.xml
@@ -14,7 +14,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <exec_depend>diagnostic_aggregator</exec_depend>
-  <exec_depend>ds4drv-pip</exec_depend>
   <exec_depend>fetch_description</exec_depend>
   <exec_depend>fetch_drivers</exec_depend>
   <exec_depend>fetch_navigation</exec_depend>


### PR DESCRIPTION
ROS buildfarm doesn't support pip dependencies.  See here for more info: https://github.com/ros-infrastructure/ros_buildfarm/issues/643

Also removed outdated sixad line. We don't install sixad at all in 18.04.
