### PR TITLE
fetch system config improvements (v0.2)

### DIFF
--- a/fetch_system_config/README.md
+++ b/fetch_system_config/README.md
@@ -4,13 +4,23 @@ This is the Git Build Package (GBP) repo for Research versions of Fetch/Freight.
 All other tools (iso installer, documentation, etc), and the commercial version
 of this package, are on the 'master' branch.
 
+The latest tested fetch and freight system config debians are available from:
+
+- http://packages.fetchrobotics/binaries/fetch-melodic-config.deb
+- http://packages.fetchrobotics/binaries/freight-melodic-config.deb
+
+However, for best results in upgrading, please follow
+http://docs.fetchrobotics.com/care_and_feeding.html#updating-your-robot
+
 # How to Manually Build
 
 ```bash
 git clone git@github.com:fetchrobotics/fetch_robots.git # -b melodic-devel
 cd fetch_robots/fetch_system_config
-# Optionally auto-update changelog via git commits
-gbp dch --release
+# If prepparing for a new release, update changelog
+dch
+# Bump version
+dch --release
 dpkg-buildpackage -us -uc
 # Debians are placed in the parent directory
 cd ..

--- a/fetch_system_config/debian/changelog
+++ b/fetch_system_config/debian/changelog
@@ -1,5 +1,17 @@
+fetch-system-config (0.2-0ubuntu1) bionic; urgency=medium
+
+  * Add PS4 support via ds4drv (via pip installation)
+  * Fix PS3 controller udev rule so that /dev/ps3joy is generated
+  * Modify logging by systemd services, due to limitations of v237
+  * Remove ethernet gateway specification
+  * Custom grub settings no long directly added to /etc/default/grub
+  * Modify grub to bypass Plymouth splash screen
+  * Set power button behavior so that computer shuts down properly
+
+ -- Eric Relson <erelson@fetchrobotics.com>  Fri, 26 Jul 2019 09:25:50 -0700
+
 fetch-system-config (0.1-0) bionic; urgency=medium
 
   * initial release of melodic packages
 
- -- Eric Relson <erelson@fetchrobotics.com> Fri, 01 Feb 2019 10:50:25 -0800
+ -- Eric Relson <erelson@fetchrobotics.com>  Fri, 01 Feb 2019 10:50:25 -0800

--- a/fetch_system_config/debian/fetch-melodic-config.postinst
+++ b/fetch_system_config/debian/fetch-melodic-config.postinst
@@ -44,9 +44,8 @@ case "$1" in
         # https://unix.stackexchange.com/a/416569
         hostnamectl set-chassis vm
 
-        # Do not wait for GRUB (we're headless)
-        sed -i "s/GRUB_TIMEOUT=.*\"\"/GRUB_TIMEOUT=5/" /etc/default/grub
-        echo "GRUB_RECORDFAIL_TIMEOUT=\$GRUB_TIMEOUT" >> /etc/default/grub
+        # Apply the combination of /etc/default/grub and /etc/default/grub.d/50-fetch.cfg
+        update-grub
 
         # Disable apport
         if [ -e "/etc/default/apport" ]; then
@@ -63,9 +62,6 @@ case "$1" in
 
         ### Set up ethernet to ensure static network for internal robot communications.
         # Reboot required for changes to take effect.
-        # Modify default/grub to not use new-style network device naming
-        sed -i "s/GRUB_CMDLINE_LINUX=\"\"/GRUB_CMDLINE_LINUX=\"net.ifnames=0 biosdevname=0\"/" /etc/default/grub
-        update-grub
         # Determine which device to map to eth0 and eth1 and update /etc/udev/rules.d/70-persistent-net.rules
         declare -a x=()
         lines=$(udevadm info -e | grep -e "ID_NET_NAME_MAC=e.*[a-f0-9]\{12\}$")

--- a/fetch_system_config/debian/fetch-melodic-config.robot.logrotate
+++ b/fetch_system_config/debian/fetch-melodic-config.robot.logrotate
@@ -1,0 +1,8 @@
+/var/log/ros/robot.log {
+    su ros ros
+    maxsize=50M
+    rotate 7
+    missingok
+    delaycompress
+    copytruncate
+}

--- a/fetch_system_config/debian/fetch-melodic-config.robot.service
+++ b/fetch_system_config/debian/fetch-melodic-config.robot.service
@@ -13,5 +13,5 @@ StandardOutput=file:/var/log/ros/robot.log
 StandardError=file:/var/log/ros/robot.log
 
 User=ros
-ExecStartPre=+/usr/sbin/logrotate.d/robot -f
+ExecStartPre=+/usr/sbin/logrotate /etc/logrotate.d/robot -f
 ExecStart=/bin/bash -c ". /opt/ros/melodic/setup.bash && roslaunch /etc/ros/melodic/robot.launch --wait"

--- a/fetch_system_config/debian/fetch-melodic-config.robot.service
+++ b/fetch_system_config/debian/fetch-melodic-config.robot.service
@@ -9,9 +9,9 @@ WantedBy=roscore.service
 [Service]
 Environment="ROS_LOG_DIR=/var/log/ros"
 Restart=on-failure
-StandardOutput=syslog
-StandardError=syslog
-SyslogIdentifer=robot
+StandardOutput=file:/var/log/ros/robot.log
+StandardError=file:/var/log/ros/robot.log
 
 User=ros
+ExecStartPre=+/usr/sbin/logrotate.d/robot -f
 ExecStart=/bin/bash -c ". /opt/ros/melodic/setup.bash && roslaunch /etc/ros/melodic/robot.launch --wait"

--- a/fetch_system_config/debian/fetch-melodic-config.ros.logrotate
+++ b/fetch_system_config/debian/fetch-melodic-config.ros.logrotate
@@ -41,13 +41,6 @@ compress
     delaycompress
 }
 
-/var/log/robot.log {
-    maxsize=50M
-    rotate 7
-    missingok
-    delaycompress
-}
-
 /var/log/ros/robot_log.csv {
     maxsize 100M
     weekly

--- a/fetch_system_config/debian/freight-melodic-config.postinst
+++ b/fetch_system_config/debian/freight-melodic-config.postinst
@@ -44,9 +44,8 @@ case "$1" in
         # https://unix.stackexchange.com/a/416569
         hostnamectl set-chassis vm
 
-        # Do not wait for GRUB (we're headless)
-        sed -i "s/GRUB_TIMEOUT=.*\"\"/GRUB_TIMEOUT=5/" /etc/default/grub
-        echo "GRUB_RECORDFAIL_TIMEOUT=\$GRUB_TIMEOUT" >> /etc/default/grub
+        # Apply the combination of /etc/default/grub and /etc/default/grub.d/50-fetch.cfg
+        update-grub
 
         # Disable apport
         if [ -e "/etc/default/apport" ]; then
@@ -63,9 +62,6 @@ case "$1" in
 
         ### Set up ethernet to ensure static network for internal robot communications.
         # Reboot required for changes to take effect.
-        # Modify default/grub to not use new-style network device naming
-        sed -i "s/GRUB_CMDLINE_LINUX=\"\"/GRUB_CMDLINE_LINUX=\"net.ifnames=0 biosdevname=0\"/" /etc/default/grub
-        update-grub
         # Determine which device to map to eth0 and eth1 and update /etc/udev/rules.d/70-persistent-net.rules
         declare -a x=()
         lines=$(udevadm info -e | grep -e "ID_NET_NAME_MAC=e.*[a-f0-9]\{12\}$")

--- a/fetch_system_config/debian/freight-melodic-config.robot.logrotate
+++ b/fetch_system_config/debian/freight-melodic-config.robot.logrotate
@@ -1,1 +1,1 @@
-debian/fetch-melodic-config.robot.logrotate
+fetch-melodic-config.robot.logrotate

--- a/fetch_system_config/debian/freight-melodic-config.robot.logrotate
+++ b/fetch_system_config/debian/freight-melodic-config.robot.logrotate
@@ -1,0 +1,1 @@
+debian/fetch-melodic-config.robot.logrotate

--- a/fetch_system_config/root/etc/acpi/events/powerbtn
+++ b/fetch_system_config/root/etc/acpi/events/powerbtn
@@ -1,0 +1,13 @@
+# /etc/acpi/events/powerbtn
+# This is called when the user presses the power button and calls
+# /etc/acpi/powerbtn.sh for further processing.
+
+# Optionally you can specify the placeholder %e. It will pass
+# through the whole kernel event message to the program you've
+# specified.
+
+# We need to react on "button power.*" and "button/power.*" because
+# of kernel changes.
+
+event=button[ /]power
+action=/etc/acpi/powerbtn.sh

--- a/fetch_system_config/root/etc/acpi/powerbtn.sh
+++ b/fetch_system_config/root/etc/acpi/powerbtn.sh
@@ -1,0 +1,2 @@
+# Just initiate a plain shutdown.
+/sbin/shutdown -h now "Power button pressed or power-button signal received from mainboard...\n...shutting down now!"

--- a/fetch_system_config/root/etc/default/grub.d/50-fetch.cfg
+++ b/fetch_system_config/root/etc/default/grub.d/50-fetch.cfg
@@ -1,0 +1,13 @@
+# These will override/add to entries in /etc/default/grub
+# This file is an undocumented Ubuntu feature, described here:
+# https://bugs.launchpad.net/ubuntu/+source/grub2/+bug/901600
+
+# Do not wait forever for GRUB (we're headless)
+GRUB_TIMEOUT=5
+# Additionally, in case of e.g. power cut in middle of boot, don't pause indefinitely at grub selection
+GRUB_RECORDFAIL_TIMEOUT=$GRUB_TIMEOUT
+# Disable plymouth splash screen; prevents sometimes getting stuck when headless.
+# We omit "splash" from the default line
+GRUB_CMDLINE_LINUX_DEFAULT="quiet"
+# Do not use new-style network device naming; stick to eth0, wlan0, etc.
+GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0"


### PR DESCRIPTION
Tested and works.  

The biggest improvement is that I think I've gotten around the issue where systemd wouldn't fully start until a monitor was plugged into the robot.  The initial workaround was to change the default "target" from graphical to multi-user, resulting in GDM3 not running.  The current solution is just to disable Plymouth.  Caveat: I haven't been able to get back into this state even after re-enabling plymouth, so I'm not 100% confident in this.

I also redid how we specify grub config additions. The new way will avoid users getting confused during install regarding "updated" versions of /etc/default/grub.  (However, users who have already upgraded to 18.04 will likely encounter this prompt next time they do an apt-get upgrade...)

I'll do some more power button testing soon, as there's still some mysterious things going on.