### PR TITLE
Add missing logrotate install rule

### DIFF
--- a/fetch_system_config/debian/rules
+++ b/fetch_system_config/debian/rules
@@ -10,6 +10,7 @@ override_dh_systemd_enable:
 
 override_dh_installlogrotate:
 	dh_installlogrotate --name=ros
+	dh_installlogrotate --name=robot
 
 %:
 	dh $@ --with=systemd


### PR DESCRIPTION
I should have had a DNM tag on my recent PR.

Tested this last night after finally realizing this was why the logrotate rule for the robot service was missing upon install...

(Note this fix is independent of the release of ROS packages; I've already pushed the updated debian to packages.fetchrobotics.com)