### PR TITLE
Fix ownership of robot driver logs

### DIFF
--- a/fetch_system_config/debian/fetch-melodic-config.postinst
+++ b/fetch_system_config/debian/fetch-melodic-config.postinst
@@ -31,6 +31,8 @@ case "$1" in
         if [ ! -e "/var/log/ros" ]; then
             mkdir /var/log/ros
         fi
+        touch /var/log/ros/robot.log  # Otherwise systemd will make this file root:ros
+                                      #  with 755 instead of ros:ros with 775
         chown -R ros:ros /var/log/ros
         chmod 2775 /var/log/ros
 

--- a/fetch_system_config/debian/freight-melodic-config.postinst
+++ b/fetch_system_config/debian/freight-melodic-config.postinst
@@ -31,6 +31,8 @@ case "$1" in
         if [ ! -e "/var/log/ros" ]; then
             mkdir /var/log/ros
         fi
+        touch /var/log/ros/robot.log  # Otherwise systemd will make this file root:ros
+                                      #  with 755 instead of ros:ros with 775
         chown -R ros:ros /var/log/ros
         chmod 2775 /var/log/ros
 


### PR DESCRIPTION
Accounts for non ros-writeable log file presumably created by systemd (maybe this is a bug in systemd?).  More specifically, without doing this touch, we would end up with a root:ros owned file with 744 permissions, sot he ROS user was unable to write to the file.  I did not find anything in systemd that I should change in the service file itself.  Related lines: https://github.com/fetchrobotics/fetch_robots/blob/melodic-devel/fetch_system_config/debian/fetch-melodic-config.robot.service#L12-L15

(This fix is already pushed to the latest debian and has been tested a couple times now; we saw similar issues with some of our services for commercial robots)