### PR TITLE
Add soundplay ROS node as systemd service

### DIFF
--- a/fetch_bringup/package.xml
+++ b/fetch_bringup/package.xml
@@ -29,6 +29,6 @@
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend version_gte="0.0.4">sick_tim</exec_depend>
-  <exec_depend>soundplay</exec_depend>
+  <exec_depend>sound_play</exec_depend>
 
 </package>

--- a/fetch_bringup/package.xml
+++ b/fetch_bringup/package.xml
@@ -29,5 +29,6 @@
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend version_gte="0.0.4">sick_tim</exec_depend>
+  <exec_depend>soundplay</exec_depend>
 
 </package>

--- a/fetch_system_config/debian/changelog
+++ b/fetch_system_config/debian/changelog
@@ -1,3 +1,9 @@
+fetch-system-config (0.2-0ubuntu2) trusty; urgency=medium
+
+  * Add soundplay node systemd service for Fetch and Freight
+
+ -- Eric Relson <erelson@sw18>  Thu, 29 Aug 2019 17:52:35 -0700
+
 fetch-system-config (0.2-0ubuntu1) bionic; urgency=medium
 
   * Add PS4 support via ds4drv (via pip installation)

--- a/fetch_system_config/debian/fetch-melodic-config.soundplay.service
+++ b/fetch_system_config/debian/fetch-melodic-config.soundplay.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Job that launches the soundplay node once roscore has started
+After=roscore.service
+BindsTo=roscore.service
+
+[Install]
+WantedBy=roscore.service
+
+[Service]
+Environment="ROS_LOG_DIR=/var/log/ros"
+Restart=on-failure
+
+User=ros
+ExecStart=/bin/bash -c ". /opt/ros/melodic/setup.bash && rosrun sound_play soundplay_node.py"
+

--- a/fetch_system_config/debian/freight-melodic-config.soundplay.service
+++ b/fetch_system_config/debian/freight-melodic-config.soundplay.service
@@ -1,0 +1,1 @@
+fetch-melodic-config.soundplay.service

--- a/fetch_system_config/debian/rules
+++ b/fetch_system_config/debian/rules
@@ -5,6 +5,7 @@
 override_dh_systemd_enable:
 	dh_systemd_enable --name=roscore
 	dh_systemd_enable --name=robot
+	dh_systemd_enable --name=soundplay
 	dh_systemd_enable --name=ps4joy --no-enable
 	dh_systemd_enable --name=ps3joy --no-enable
 

--- a/freight_bringup/package.xml
+++ b/freight_bringup/package.xml
@@ -23,6 +23,7 @@
   <exec_depend>joy</exec_depend>
   <exec_depend>ps3joy</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>sick_tim</exec_depend>
+  <exec_depend version_gte="0.0.4">sick_tim</exec_depend>
+  <exec_depend>soundplay</exec_depend>
 
 </package>

--- a/freight_bringup/package.xml
+++ b/freight_bringup/package.xml
@@ -24,6 +24,6 @@
   <exec_depend>ps3joy</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend version_gte="0.0.4">sick_tim</exec_depend>
-  <exec_depend>soundplay</exec_depend>
+  <exec_depend>sound_play</exec_depend>
 
 </package>


### PR DESCRIPTION
Functionality existed in 14.04/indigo, and was initially left out.

Tested the fetch-melodic-config debian with this on Fetch1.  Manually installed the soundplay package, which would otherwise get pulled in by the latest ros-melodic-fetch-bringup package.