### PR TITLE
use robot_localization instead of graft

### DIFF
--- a/fetch_bringup/config/robot_localization.yaml
+++ b/fetch_bringup/config/robot_localization.yaml
@@ -1,0 +1,27 @@
+frequency: 50
+sensor_timeout: 1.0
+two_d_mode: true
+publish_tf: true
+publish_acceleration: false
+map_frame: map
+odom_frame: odom
+base_link_frame: base_link
+# odom
+odom0: /odom
+odom0_config: [true, true, false,
+               false, false, true,
+               true, true, false,
+               false, false, true,
+               false, false, false]
+odom0_nodelay: true
+odom0_differential: true
+# imu
+imu0: /imu
+imu0_config: [false, false, false,
+              false, false, false,
+              false, false, false,
+              false, false, true,
+              true, true, false]
+imu0_nodelay: true
+imu0_differential: true
+imu0_remove_gravitational_acceleration: true

--- a/fetch_bringup/config/robot_localization.yaml
+++ b/fetch_bringup/config/robot_localization.yaml
@@ -18,10 +18,10 @@ odom0_differential: true
 # imu
 imu0: /imu
 imu0_config: [false, false, false,
-              false, false, false,
+              false, false, true,
               false, false, false,
               false, false, true,
-              true, true, false]
+              true, false, false]
 imu0_nodelay: true
 imu0_differential: true
 imu0_remove_gravitational_acceleration: true

--- a/fetch_bringup/launch/fetch.launch
+++ b/fetch_bringup/launch/fetch.launch
@@ -20,7 +20,9 @@
 
   <!-- Odometry -->
   <param name="base_controller/publish_tf" value="false" />
-  <include file="$(find fetch_bringup)/launch/include/graft.launch.xml" />
+  <!-- switch to use robot_localization -->
+  <!-- <include file="$(find fetch_bringup)/launch/include/graft.launch.xml" /> -->
+  <include file="$(find fetch_bringup)/launch/include/robot_localization.launch.xml" />
 
   <!-- URDF -->
   <param name="robot_description" textfile="$(find fetch_description)/robots/fetch.urdf" />

--- a/fetch_bringup/launch/include/robot_localization.launch.xml
+++ b/fetch_bringup/launch/include/robot_localization.launch.xml
@@ -1,0 +1,9 @@
+<launch>
+
+  <!-- robot localization ukf -->
+  <node pkg="robot_localization" type="ukf_localization_node" name="ukf_se" clear_params="true">
+    <remap from="odometry/filtered" to="/odom_combined" />
+    <rosparam file="$(find fetch_bringup)/config/robot_localization.yaml" command="load" />
+  </node>
+
+</launch>

--- a/fetch_bringup/package.xml
+++ b/fetch_bringup/package.xml
@@ -26,6 +26,7 @@
   <exec_depend>joy</exec_depend>
   <exec_depend>openni2_launch</exec_depend>
   <exec_depend>ps3joy</exec_depend>
+  <exec_depend>robot_localization</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend version_gte="0.0.4">sick_tim</exec_depend>


### PR DESCRIPTION
Switch from `graft` to `robot_localization`
`graft` is no more maintained.
(see https://github.com/ros-perception/graft/issues/29)

we are now testing on our fetch robot with Indigo.
we cannot test it on melodic because we don't have melodic fetch and any plan to update our fetch to melodic.

related: https://github.com/jsk-ros-pkg/jsk_robot/pull/1147