### PR TITLE
Respawn tuck_arm node on shutdown [OPEN-48]

### DIFF
--- a/fetch_bringup/launch/include/teleop.launch.xml
+++ b/fetch_bringup/launch/include/teleop.launch.xml
@@ -30,6 +30,7 @@
 
   <node name="controller_reset" pkg="fetch_bringup" type="controller_reset.py" />
 
-  <node name="tuck_arm" pkg="fetch_teleop" type="tuck_arm.py" args="--joystick" />
+  <!-- arm tuck shuts down purposely on success, relies on roslaunch respawn -->
+  <node name="tuck_arm" pkg="fetch_teleop" type="tuck_arm.py" args="--joystick" respawn="true" />
 
 </launch>


### PR DESCRIPTION
Arm tuck node is not being respawned and it relies on this happening.

From the source itself:
https://github.com/fetchrobotics/fetch_ros/blob/melodic-devel/fetch_teleop/scripts/tuck_arm.py#L100
```
# On success quit
# Stopping the MoveIt thread works, however, the action client
# does not get shut down, and future tucks will not work.
# As a work-around, we die and roslaunch will respawn us.
```

See also:
https://github.com/fetchrobotics/fetch_ros/pull/150

Please review @erelson 