### PR TITLE
Enable to choose whether to start up diagnostics aggregator

### DIFF
--- a/fetch_bringup/launch/fetch.launch
+++ b/fetch_bringup/launch/fetch.launch
@@ -3,6 +3,7 @@
   <param name="robot/type" value="fetch" />
   <param name="robot/name" textfile="/etc/hostname" />
   <arg name="launch_teleop" default="true" />
+  <arg name="launch_diagnostics_agg" default="true" />
 
   <!-- GDB Debug Option -->
   <arg name="debug" default="false" />
@@ -69,6 +70,7 @@
   </include>
 
   <!-- Diagnostics Aggregator -->
-  <include file="$(find fetch_bringup)/launch/include/aggregator.launch.xml" />
+  <include if="$(arg launch_diagnostics_agg)"
+           file="$(find fetch_bringup)/launch/include/aggregator.launch.xml" />
 
 </launch>

--- a/freight_bringup/launch/freight.launch
+++ b/freight_bringup/launch/freight.launch
@@ -3,6 +3,7 @@
   <param name="robot/type" value="freight" />
   <param name="robot/name" textfile="/etc/hostname" />
   <arg name="launch_teleop" default="true" />
+  <arg name="launch_diagnostics_agg" default="true" />
 
   <!-- Calibration -->
   <param name="calibration_date" value="uncalibrated"/>
@@ -43,6 +44,7 @@
   <include file="$(find fetch_open_auto_dock)/launch/auto_dock.launch" />
 
   <!-- Diagnostics Aggregator -->
-  <include file="$(find freight_bringup)/launch/include/aggregator.launch.xml" />
+  <include if="$(arg launch_diagnostics_agg)"
+           file="$(find freight_bringup)/launch/include/aggregator.launch.xml" />
 
 </launch>


### PR DESCRIPTION
We are trying to launching our own diagnostics aggregator.

To avoid interfering with the diagnostic aggregator launched by `fetch(freight).launch`, I add the startup options.